### PR TITLE
Compatibility with character accent Brazilian

### DIFF
--- a/CsvFile.php
+++ b/CsvFile.php
@@ -86,6 +86,16 @@ class CsvFile extends Object
     }
 
     /**
+     * write BOM into UTF-8 encoded file to properly display characters
+     * @return boolean success.
+     */
+    public function composeUt8Bom()
+    {
+        $this->open();
+        return $this->writeContent(pack("CCC",0xef,0xbb,0xbf));
+    }
+
+    /**
      * Close the related file if it was opened.
      * @return boolean success.
      */

--- a/ExportResult.php
+++ b/ExportResult.php
@@ -55,6 +55,11 @@ class ExportResult extends Object
      * @var boolean whether to always archive result, even if has only single file.
      */
     public $forceArchive = false;
+    /**
+     *
+     * @var boolean enable to write BOM into UTF-8 encoded file to properly display characters in some programs.
+     */
+    public $enableUtfBom = false;
 
     /**
      * @var string temporary files directory name
@@ -131,7 +136,10 @@ class ExportResult extends Object
 
         $file = new CsvFile($config);
         $file->name = $this->getDirName() . DIRECTORY_SEPARATOR . $selfFileName . '.csv';
-
+	if ($this->enableUtfBom === true) {
+            $file->composeUt8Bom();
+        }
+	
         $this->csvFiles[] = $file;
 
         return $file;


### PR DESCRIPTION
When exporting files that contain character accents, there is a problem where for example the word 'NO' export as 'NO'.
Added UTF-8 BOM at the beginning of the file with a flag solves the problem.

usable:
`$export = new CsvGrid([
            'resultConfig' => [
                'enableUtfBom' => true,
            ], ....`